### PR TITLE
Always create readable JSON strings.

### DIFF
--- a/core.go
+++ b/core.go
@@ -91,7 +91,7 @@ func (api *API) requestHandler(resource interface{}) http.HandlerFunc {
 
 		code, data, header := handler(request.Form, request.Header)
 
-		content, err := json.Marshal(data)
+		content, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
 			rw.WriteHeader(http.StatusInternalServerError)
 			return

--- a/core_test.go
+++ b/core_test.go
@@ -27,7 +27,7 @@ func TestBasicGet(t *testing.T) {
 		t.Error(err)
 	}
 	body, _ := ioutil.ReadAll(resp.Body)
-	if string(body) != `{"items":["item1","item2"]}` {
+	if string(body) != "{\n  \"items\": [\n    \"item1\",\n    \"item2\"\n  ]\n}" {
 		t.Error("Not equal.")
 	}
 }


### PR DESCRIPTION
JSON API should return readable JSON code.The cost of the extra data transfer is negligible, especially when you compare to the cost of not implementing gzip.

For more info on that matter please see http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#pretty-print-gzip
