### PR TITLE
Added SetMux feature

### DIFF
--- a/core.go
+++ b/core.go
@@ -131,6 +131,7 @@ func (api *API) SetMux(mux APIMux) error {
 		return errors.New("You cannot set a muxer when already initialized.")
 	} else {
 		api.mux = mux
+		api.muxInitialized = true
 		return nil
 	}
 }


### PR DESCRIPTION
This PR adds support to use sleepy with existing muxer instances and also allows to use other muxer implementations than http.http.ServeMux.
