### PR TITLE
Make full request available to handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ Sleepy is a micro-framework for building RESTful APIs.
 package main
 
 import (
-    "net/url"
     "net/http"
     "github.com/dougblack/sleepy"
 )
 
 type Item struct { }
 
-func (item Item) Get(values url.Values, headers http.Header) (int, interface{}, http.Header) {
+func (item Item) Get(request *http.Request) (int, interface{}, http.Header) {
     items := []string{"item1", "item2"}
     data := map[string][]string{"items": items}
     return 200, data, http.Header{"Content-type": {"application/json"}}

--- a/core.go
+++ b/core.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 )
 
 const (
@@ -18,25 +17,25 @@ const (
 // GetSupported is the interface that provides the Get
 // method a resource must support to receive HTTP GETs.
 type GetSupported interface {
-	Get(url.Values, http.Header) (int, interface{}, http.Header)
+	Get(*http.Request) (int, interface{}, http.Header)
 }
 
 // PostSupported is the interface that provides the Post
 // method a resource must support to receive HTTP POSTs.
 type PostSupported interface {
-	Post(url.Values, http.Header) (int, interface{}, http.Header)
+	Post(*http.Request) (int, interface{}, http.Header)
 }
 
 // PutSupported is the interface that provides the Put
 // method a resource must support to receive HTTP PUTs.
 type PutSupported interface {
-	Put(url.Values, http.Header) (int, interface{}, http.Header)
+	Put(*http.Request) (int, interface{}, http.Header)
 }
 
 // DeleteSupported is the interface that provides the Delete
 // method a resource must support to receive HTTP DELETEs.
 type DeleteSupported interface {
-	Delete(url.Values, http.Header) (int, interface{}, http.Header)
+	Delete(*http.Request) (int, interface{}, http.Header)
 }
 
 // An API manages a group of resources by routing requests
@@ -63,7 +62,7 @@ func (api *API) requestHandler(resource interface{}) http.HandlerFunc {
 			return
 		}
 
-		var handler func(url.Values, http.Header) (int, interface{}, http.Header)
+		var handler func(*http.Request) (int, interface{}, http.Header)
 
 		switch request.Method {
 		case GET:
@@ -89,7 +88,7 @@ func (api *API) requestHandler(resource interface{}) http.HandlerFunc {
 			return
 		}
 
-		code, data, header := handler(request.Form, request.Header)
+		code, data, header := handler(request)
 
 		content, err := json.Marshal(data)
 		if err != nil {

--- a/core_test.go
+++ b/core_test.go
@@ -3,13 +3,12 @@ package sleepy
 import (
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"testing"
 )
 
 type Item struct{}
 
-func (item Item) Get(values url.Values, headers http.Header) (int, interface{}, http.Header) {
+func (item Item) Get(*http.Request) (int, interface{}, http.Header) {
 	items := []string{"item1", "item2"}
 	data := map[string][]string{"items": items}
 	return 200, data, nil


### PR DESCRIPTION
This PR is required to get access to request.Body in POST and PUT handlers without keeping to add more and more parameters to the handlers. I feel it is much easier when the http.Request is available to handlers directly.
