### PR TITLE
converting to use interface, to allow for mocking in unit tests

### DIFF
--- a/core.go
+++ b/core.go
@@ -53,23 +53,42 @@ type PatchSupported interface {
 	Patch(url.Values, http.Header) (int, interface{}, http.Header)
 }
 
-// An API manages a group of resources by routing requests
+// API is the interface to manage a group of resources by routing requests
+// to the correct method on a matching resource and marshalling
+// the returned data to JSON for the HTTP response.
+type API interface {
+	// Mux returns the http.ServeMux used by an API. If a ServeMux has
+	// does not yet exist, a new one will be created and returned.
+	Mux() *http.ServeMux
+	// AddResource adds a new resource to an API. The API will route
+	// requests that match one of the given paths to the matching HTTP
+	// method on the resource.
+	AddResource(resource interface{}, paths ...string)
+	// AddResourceWithWrapper behaves exactly like AddResource but wraps
+	// the generated handler function with a give wrapper function to allow
+	// to hook in Gzip support and similar.
+	AddResourceWithWrapper(resource interface{}, wrapper func(handler http.HandlerFunc) http.HandlerFunc, paths ...string)
+	// Start causes the API to begin serving requests on the given port.
+	Start(port int) error
+}
+
+// An DefaultAPI manages a group of resources by routing requests
 // to the correct method on a matching resource and marshalling
 // the returned data to JSON for the HTTP response.
 //
 // You can instantiate multiple APIs on separate ports. Each API
 // will manage its own set of resources.
-type API struct {
-	mux     *http.ServeMux
+type DefaultAPI struct {
+	mux            *http.ServeMux
 	muxInitialized bool
 }
 
 // NewAPI allocates and returns a new API.
-func NewAPI() *API {
-	return &API{}
+func NewAPI() API {
+	return &DefaultAPI{}
 }
 
-func (api *API) requestHandler(resource interface{}) http.HandlerFunc {
+func (api *DefaultAPI) requestHandler(resource interface{}) http.HandlerFunc {
 	return func(rw http.ResponseWriter, request *http.Request) {
 
 		if request.ParseForm() != nil {
@@ -130,20 +149,20 @@ func (api *API) requestHandler(resource interface{}) http.HandlerFunc {
 
 // Mux returns the http.ServeMux used by an API. If a ServeMux has
 // does not yet exist, a new one will be created and returned.
-func (api *API) Mux() *http.ServeMux {
+func (api *DefaultAPI) Mux() *http.ServeMux {
 	if api.muxInitialized {
 		return api.mux
-	} else {
-		api.mux = http.NewServeMux()
-		api.muxInitialized = true
-		return api.mux
 	}
+
+	api.mux = http.NewServeMux()
+	api.muxInitialized = true
+	return api.mux
 }
 
 // AddResource adds a new resource to an API. The API will route
 // requests that match one of the given paths to the matching HTTP
 // method on the resource.
-func (api *API) AddResource(resource interface{}, paths ...string) {
+func (api *DefaultAPI) AddResource(resource interface{}, paths ...string) {
 	for _, path := range paths {
 		api.Mux().HandleFunc(path, api.requestHandler(resource))
 	}
@@ -152,14 +171,14 @@ func (api *API) AddResource(resource interface{}, paths ...string) {
 // AddResourceWithWrapper behaves exactly like AddResource but wraps
 // the generated handler function with a give wrapper function to allow
 // to hook in Gzip support and similar.
-func (api *API) AddResourceWithWrapper(resource interface{}, wrapper func(handler http.HandlerFunc) http.HandlerFunc, paths ...string) {
+func (api *DefaultAPI) AddResourceWithWrapper(resource interface{}, wrapper func(handler http.HandlerFunc) http.HandlerFunc, paths ...string) {
 	for _, path := range paths {
 		api.Mux().HandleFunc(path, wrapper(api.requestHandler(resource)))
 	}
 }
 
 // Start causes the API to begin serving requests on the given port.
-func (api *API) Start(port int) error {
+func (api *DefaultAPI) Start(port int) error {
 	if !api.muxInitialized {
 		return errors.New("You must add at least one resource to this API.")
 	}


### PR DESCRIPTION
For best practices in allowing for others to mock packages for unit tests of their own code, packages should export interfaces - especially from the New() convention.

This pull request remains backwards compatible with all existing code.  Read: `NewAPI()` isn't broken and remains functional, along with all func()s on the returned object.

In addition, the existing `go test` tests continue to run (just the 1 lightweight one already there).

The difference now is that `NewAPI()` returns an interface instead of a pointer (thank you for using a pointer! it is the perfect replacement with an interface).  That interface exports the exact same func()s.  Only now, an end-user (like myself) can mockup a test struct to use in place of that interface for unit tests.