### PR TITLE
Using embedding instead of type check for http methods

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 )
 
-type Item struct{}
+type Item struct{
+				NotSupported
+} 
 
 func (item Item) Get(values url.Values, headers http.Header) (int, interface{}, http.Header) {
 	items := []string{"item1", "item2"}


### PR DESCRIPTION
Inherit not supported method implementation for HTTP methods.